### PR TITLE
Remove Dancer2::Test references from module dist

### DIFF
--- a/META.json
+++ b/META.json
@@ -26,7 +26,6 @@
    "prereqs" : {
       "build" : {
          "requires" : {
-            "Dancer2::Test" : "0",
             "Plack::Test" : "0",
             "Test::LWP::UserAgent" : "0",
             "Test::More" : "0"

--- a/cpanfile
+++ b/cpanfile
@@ -3,7 +3,6 @@ requires 'WWW::Sixpack', '0.02';
 requires 'perl', '5.006';
 
 on build => sub {
-    requires 'Dancer2::Test';
     requires 'Test::LWP::UserAgent';
     requires 'Test::More';
     requires 'Plack::Test';


### PR DESCRIPTION
Dancer2::Test was soft deprecated in v0.400000, and will be hard deprecated in v1.0.0. Removing all traces of it from here.

We're trying to be good citizens and send PRs to projects we know will be unable to install when we release Dancer2 1.0.0. Please try to get this merged ASAP, as we're maybe a week away from releasing.

Please let me know if you have any questions. Thanks!